### PR TITLE
Interim Results Page with Pre-Signup and Post Sign-Up shows

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: :home
+  skip_before_action :authenticate_user!, only: %i[home results]
 
   def home
   end
@@ -7,9 +7,25 @@ class PagesController < ApplicationController
   def results
     @industry_to = params[:query_to]
     @industry_from = params[:query_from]
-    
-    @results = User.where.not(id:current_user.id)
+
+    if current_user.nil?
+      @results = User.all
+    else
+      @results = User.where.not(id: current_user.id)
+    end
+
     @search_filter_to = @results.where("future_role ~* ?", @industry_to)
     @users = @search_filter_to.where("current_industry ~* ?", @industry_from)
+
+    if @results.empty?
+      @shortlisted_profiles = @results
+      @shortlist_msg = 'We could not find any matches!'
+    elsif @users.empty?
+      @shortlisted_profiles = @search_filter_to
+      @shortlist_msg = 'We could not find exact matches for your current industry but you may want to look up these....'
+    else
+      @shortlisted_profiles = @users
+      @shortlist_msg = 'Here are profiles that exactly match your search !'
+    end
   end
 end

--- a/app/javascript/components/profile_modal.js
+++ b/app/javascript/components/profile_modal.js
@@ -1,0 +1,71 @@
+const profileModal = () => {
+  const modal = document.querySelector("#resultsModal");
+  
+  if (modal) {
+    const currentUserEmail = document.getElementById("current-user-email");
+    if (currentUserEmail) {
+    }
+    else {
+      const profiles = document.querySelectorAll('.profiles');
+      profiles.forEach(blurProfiles);
+    }
+    
+    $('#resultsModal').on('show.bs.modal', function (event) {
+      var button = $(event.relatedTarget) // Button that triggered the modal
+      var matchedUserId = button.data('matched-user-id')
+      var matchedFirstNm = button.data('matched-first-name')
+      var matchedLastNm = button.data('matched-last-name')
+      
+      var matchedCurrentRole = button.data('matched-current-role')
+      var matchedCurrentInd = button.data('matched-current-ind')
+      var matchedFutInd = button.data('matched-fut-ind')
+      var matchedImg = button.data('matched-img')
+
+      var modal = $(this)
+      
+    })
+  }
+}
+
+function blurProfiles(item, index) {
+  const profileBtn = item.querySelector(".profile-btn")
+  const matchedImgDiv = item.querySelector(".matched-img-div")
+  const firstName = item.querySelector(".first-name")
+  const lastName = item.querySelector(".last-name")
+  const currentRole = item.querySelector(".current-role")
+  const currentInd = item.querySelector(".current-ind")
+  const futureInd = item.querySelector(".future-ind")
+  
+  if (index > 2) {
+    item.classList.add("bg-secondary")
+    firstName.innerText = "****"
+    lastName.innerText = "****"
+    currentRole.innerText = "----"
+    currentInd.innerText = "----"
+    futureInd.innerText = "----"
+    firstName.classList.remove("bold")
+    lastName.classList.remove("bold")
+    currentRole.classList.remove("bold")
+    currentInd.classList.remove("bold")
+    futureInd.classList.remove("bold")
+    matchedImgDiv.innerHTML=""
+    matchedImgDiv.insertAdjacentHTML('beforeend', '<img class="matched-user-image img-fluid" style="vertical-align:middle; width:70px; height: 70px; border-radius: 50%;" src="https://images.pexels.com/photos/4103409/pexels-photo-4103409.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=750&h=1260" alt="">');
+    firstName.classList.add("text-muted")
+    lastName.classList.add("text-muted")
+    currentRole.classList.add("text-muted")
+    currentInd.classList.add("text-muted")
+    futureInd.classList.add("text-muted")
+
+    profileBtn.classList.remove("btn-success")
+    profileBtn.classList.add("btn-secondary")
+    profileBtn.classList.add("text-muted")
+  }
+  else {
+    item.classList.remove("bg-secondary")
+    profileBtn.classList.remove("btn-secondary")
+    profileBtn.classList.remove("text-muted")
+    profileBtn.classList.add("btn-success")
+  } 
+}
+
+export { profileModal }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,9 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-@import 'bootstrap'
+import 'bootstrap';
+
+import { profileModal } from '../components/profile_modal';
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -16,3 +18,8 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+document.addEventListener('turbolinks:load', () => {
+  // Call your functions here, e.g:
+  // initSelect2();
+  profileModal();
+});

--- a/app/views/pages/results.html.erb
+++ b/app/views/pages/results.html.erb
@@ -1,7 +1,53 @@
-<h1> Results Page </h1>
+<h1 class="display-5">Career Switcher Match Results !</h1>
 
-<p> Industry from <strong><%= @industry_from %></strong> to <strong><%= @industry_to %></strong> </p>
+<p><span class="text-italic"> from </span><strong><%= @industry_from %></strong> <span class="text-italic"> to </span><strong><%= @industry_to %></strong> </p>
 
+<h4><%= @shortlist_msg %></h4>
+<hr>
+
+<div class="d-flex flex-wrap justify-content-between align-items-center">
+  <% @shortlisted_profiles.each do |matched_user| %>
+  <div class="profiles card mt-3 border border-success" style="width: 16rem; height: 25rem;">
+    <div class="matched-img-div text-center">
+      <img class="matched-user-image img-fluid" style="vertical-align:middle; width:70px; height: 70px; border-radius: 50%;" src="https://images.pexels.com/photos/5025111/pexels-photo-5025111.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=750&h=1260" alt="">
+    </div>
+    <br>
+    <h3 class="text-center"><span class="first-name"><%= matched_user.first_name %></span> <span class="last-name"><%= matched_user.last_name %></span></h3>
+    <br>
+    <p class="current-role font-weight-bold"><%= matched_user.current_role %>, </p>
+    <p class="current-ind font-weight-bold"><%= matched_user.current_industry %></p>
+    <p class="text-muted">to</p>
+    <p class="future-ind font-weight-bold"><%= matched_user.future_industry %></p>
+    <!-- Button to trigger modal -->
+    <button class="profile-btn btn btn-success" data-toggle="modal" data-target="#resultsModal" data-matched-user-id="<%= matched_user.id %>" data-matched-first-nm="<%= matched_user.first_name %>" data-matched-last-nm="<%= matched_user.last_name %>" data-matched-current-role="<%= matched_user.current_role %>" data-matched-current-ind="<%= matched_user.current_industry %>" data-matched-fut-ind="<%= matched_user.future_industry %>" data-matched-img="<%= matched_user.id %>">
+      Connect!
+    </button>
+  </div>
+  <% end %>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="resultsModal" tabindex="-1" aria-labelledby="resultsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="resultsModalLabel">Hi, Visitor !</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Please sign-in to view and access all features of Connectdots....
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Sign in</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 
 <% if @users.empty? %>
   <% if @search_filter_to.empty? %>
     <p>We could not find an exact search</p>
@@ -26,3 +72,4 @@
       <%= user.future_industry %>
     <% end %>
 <% end %>
+-->

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <%= link_to root_path, class: "navbar-brand" do %>
-    <%= image_tag "https://www.nicepng.com/png/detail/418-4186049_connecting-the-dots-connecting-the-dots-logo.png" %>
-    <% end %>
+  <%= image_tag "https://www.nicepng.com/png/detail/418-4186049_connecting-the-dots-connecting-the-dots-logo.png" %>
+  <% end %>
 
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
@@ -11,27 +11,30 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
-        <li class="nav-item active">
-          <%= link_to "Home", root_path, class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "My Dashboard", "/dashboard", class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "nav-link" %>
-        </li>
-        <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-        
+      <li class="nav-item active">
+        <%= link_to "Home", root_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Messages", "#", class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "My Dashboard", "/dashboard", class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+         <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "nav-link" %>
+      </li>
+      <div class="d-none" id="current-user-email">
+        <%= current_user.email %>
+      </div>
+      <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+
       <% else %>
-        <li class="nav-item">
-          <p class="nav-link">Already a member?</p>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Login", new_user_session_path, class: "nav-link" %>
-        </li>
+      <li class="nav-item">
+        <p class="nav-link">Already a member?</p>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+      </li>
       <% end %>
     </ul>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,58 +9,102 @@ require 'faker'
 
 User.destroy_all
 
-User.create!(
-  email: "user1@xyz.com",
-  password: "secret",
-    first_name: Faker::Name.female_first_name,
-    last_name: Faker::Name.last_name,
-    budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
-    timeframe: [6, 12, 18, 24].sample,
-    current_role: "Health-care Worker",
-    current_industry: "Health Care",
-    future_role: "Product Manager",
-    future_industry: "Software Engineering",
-    available_hrs_per_week: [12, 24, 36, 40, 60].sample,
-    status: '');
+male_images = [ 
+  "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260" 
+]
 
-User.create!(
-  email: "user2@xyz.com",
-  password: "secret",
-    first_name: Faker::Name.male_first_name,
-    last_name: Faker::Name.last_name,
-    budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
-    timeframe: [6, 12, 18, 24].sample,
-    current_role: "Wealth Planner",
-    current_industry: "Banking",
-    future_role: "Web Developer",
-    future_industry: "Software Engineering",
-    available_hrs_per_week: [12, 24, 36, 40, 60].sample,
-    status: '');
+female_images = [ 
+  "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
+  "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260" 
+]
 
-User.create!(
-  email: "user3@xyz.com",
-  password: "secret",
-    first_name: Faker::Name.female_first_name,
+
+
+
+current_role = ['Supervisor', 'Admin Manager', 'Contractor', 'Consultant', 'Advisor', 'Salesperson'] 
+current_ind =  ['Accounting', 'Finance', 'Health Care', 'Banking', 'Education']
+
+future_ind = ['Fullstack Engineering', 'Frontend Developer', 'Backend Developer', 'Data Analyst']
+
+i = 1
+30.times do
+  if i.odd?
+    @name1 = Faker::Name.female_first_name
+  else 
+    @name1 = Faker::Name.male_first_name
+  end
+  i += 1
+  User.create!(
+    first_name: @name1,
+    email: "#{@name1}@#{Faker::Internet.domain_name}",
+    password: "secret",
     last_name: Faker::Name.last_name,
     budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
     timeframe: [6, 12, 18, 24].sample,
-    current_role: "Insurance Agent",
-    current_industry: "Insurance",
-    future_role: "Web Developer",
-    future_industry: "Software Engineering",
+    current_role: current_role.sample,
+    current_industry: current_ind.sample,
+    future_industry: future_ind.sample,
+    future_role: "",
     available_hrs_per_week: [12, 24, 36, 40, 60].sample,
-    status: '');
-    
-User.create!(
-  email: "user4@xyz.com",
-  password: "secret",
-    first_name: Faker::Name.male_first_name,
-    last_name: Faker::Name.last_name,
-    budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
-    timeframe: [6, 12, 18, 24].sample,
-    current_role: "Stock Broker",
-    current_industry: "Equity",
-    future_role: "Web Developer",
-    future_industry: "Software Engineering",
-    available_hrs_per_week: [12, 24, 36, 40, 60].sample,
-    status: '');
+    status: '')
+end
+
+@users = User.all
+@users.each do |user|
+  user.future_role = user.future_industry
+  user.save
+end
+
+# User.create!(
+#   email: "user2@xyz.com",
+#   password: "secret",
+#     first_name: Faker::Name.male_first_name,
+#     last_name: Faker::Name.last_name,
+#     budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
+#     timeframe: [6, 12, 18, 24].sample,
+#     current_role: "Wealth Planner",
+#     current_industry: "Banking",
+#     future_role: "Web Developer",
+#     future_industry: "Software Engineering",
+#     available_hrs_per_week: [12, 24, 36, 40, 60].sample,
+#     status: '');
+# 
+# User.create!(
+#   email: "user3@xyz.com",
+#   password: "secret",
+#     first_name: Faker::Name.female_first_name,
+#     last_name: Faker::Name.last_name,
+#     budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
+#     timeframe: [6, 12, 18, 24].sample,
+#     current_role: "Insurance Agent",
+#     current_industry: "Insurance",
+#     future_role: "Web Developer",
+#     future_industry: "Software Engineering",
+#     available_hrs_per_week: [12, 24, 36, 40, 60].sample,
+#     status: '');
+#     
+# User.create!(
+#   email: "user4@xyz.com",
+#   password: "secret",
+#     first_name: Faker::Name.male_first_name,
+#     last_name: Faker::Name.last_name,
+#     budget: [500, 1000, 1500, 2000, 2500, 3000].sample,
+#     timeframe: [6, 12, 18, 24].sample,
+#     current_role: "Stock Broker",
+#     current_industry: "Equity",
+#     future_role: "Web Developer",
+#     future_industry: "Software Engineering",
+#     available_hrs_per_week: [12, 24, 36, 40, 60].sample,
+#     status: '');
+# 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,28 +9,25 @@ require 'faker'
 
 User.destroy_all
 
-male_images = [ 
-  "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260" 
-]
-
-female_images = [ 
-  "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260", 
-  "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260" 
-]
-
-
-
+# male_images = [ 
+#   "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260" 
+# ]
+# 
+# female_images = [ 
+#   "https://images.pexels.com/photos/1639557/pexels-photo-1639557.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2474661/pexels-photo-2474661.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2087748/pexels-photo-2087748.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/4194390/pexels-photo-4194390.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/1437267/pexels-photo-1437267.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/884600/pexels-photo-884600.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260", 
+#   "https://images.pexels.com/photos/2098085/pexels-photo-2098085.jpeg?auto=compress&# cs=tinysrgb&dpr=2&h=750&w=1260" 
+# ]
 
 current_role = ['Supervisor', 'Admin Manager', 'Contractor', 'Consultant', 'Advisor', 'Salesperson'] 
 current_ind =  ['Accounting', 'Finance', 'Health Care', 'Banking', 'Education']


### PR DESCRIPTION
Loom recording of test in localhost
https://www.loom.com/share/7ccc50f16b71452b95c4369beb987c70

**Summary of Changes:**
1. Selection logic of Home Page input - logic moved from View to Controller and made DRY.
2. Results page coded for showing Pre-Signup with 3 matched profiles and remaining profiles are blanked out
3. Results page coded for showing Post-Login with all matched profiles shown

**Please note:** 
- avatars are currently hardcoded images; we need to add an image-url to the User model so that Users can upload their profile images and we can display those instead
- I have created a seed with 30 users where the Current Roles and Industry values are in line with the drop-down list in the Home Page - you may want to use this seed for testing with more profiles
- after the user signs-in when in the "Results" page, he/she is taken back to the Home page. This is not nice, so I still have to add code to return user back to same page.
