### PR TITLE
Fixed Links in Results Page modals

### DIFF
--- a/app/views/pages/results.html.erb
+++ b/app/views/pages/results.html.erb
@@ -38,8 +38,10 @@
         Please sign-in or sign-up to access full features of Connectdots...
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Sign in</button>
+        <button type="button" class="btn btn-dark rounded-pill px-2 px-md-4" data-dismiss="modal">Close</button>
+        <%= link_to 'Sign in', new_user_session_path, class: 'btn btn-primary mr-2 mr-md-3 rounded-pill px-2 px-md-4' %>
+        <!-- <button type="button" class="btn btn-primary">Sign in</button> -->
+        <%= link_to 'Sign Up', new_user_registration_path, class: 'btn btn-success rounded-pill px-2 px-md-4' %>
       </div>
     </div>
   </div>
@@ -67,9 +69,9 @@
         <p>Motivation <span id="mb2-13"></span></p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-success">Connect</button>
-        <button type="button" class="btn btn-primary">Go Somewhere</button>
+        <button type="button" class="btn btn-dark rounded-pill px-2 px-md-4" data-dismiss="modal">Close</button>
+        <%= link_to 'Connect with me', requests_connections_path, class: 'btn btn-primary mr-2 mr-md-3 rounded-pill px-2 px-md-4' %>
+        <%= link_to 'See Roadmap', roadmap_path(:id), class: 'btn btn-success mr-2 mr-md-3 rounded-pill px-2 px-md-4' %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Test Video:
https://www.loom.com/share/bbe3d939b5b64263bb3f4ae1d2313864

Changes done:
1. If user is not signed in, the modal that pops up has buttons that redirect to "Sign In" and "Sign Up".
2. If user is signed in, the modal that pops up has buttons that redirect to "Connect to" the clicked user and "See Roadmap" of the clicked user.

Note: The Click action in (2) above will cause application to abort as the routing is to controllers that have not been created yet.