### PR TITLE
Back to Results from My Roadmap page

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -11,10 +11,10 @@
 
 .card {
   width: 400px;
-  height: 350px;
+  height: 360px;
   text-align: center;
   border-radius: 10px;
-  padding: 20px;
+  padding: 16px;
   border: 1px solid;
   box-shadow: 0 0 5px;
   margin-right: 100px;

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -3,3 +3,4 @@
 @import "dashboard";
 @import "sidebar";
 @import "roadmapone";
+@import "results";

--- a/app/assets/stylesheets/pages/_results.scss
+++ b/app/assets/stylesheets/pages/_results.scss
@@ -1,0 +1,3 @@
+.top-zero {
+  margin-top: 0 !important;
+}

--- a/app/javascript/components/back_to_results.js
+++ b/app/javascript/components/back_to_results.js
@@ -1,0 +1,23 @@
+const backToResults = () => {
+  const backToResultsBtn = document.getElementById('back-to-results');
+
+  if (backToResultsBtn) {
+    const queryString = location.search.substring(1);
+    const newString = queryString.replace(/%20/g, "+");
+    const tmpArray = newString.split("|")
+    const btnP2 = tmpArray[0];
+    const btnP4 = tmpArray[1];
+    // console.log(`${btnP2} ${btnP4}`)
+
+    const backToResultsBtn = document.getElementById('back-to-results');
+    // console.log(backToResultsBtn.innerHTML);
+
+    const btnP1 = '<a href="/results?query_from='
+    const btnP3 = '&query_to='
+    const btnP5 = '&commit=Search" class="btn btn-outline-success rounded-pill"   style="float: left;">Back to Results</a>'
+
+    backToResultsBtn.innerHTML = `${btnP1}${btnP2}${btnP3}${btnP4}${btnP5}`
+  }
+}
+
+export { backToResults }

--- a/app/javascript/components/profile_modal.js
+++ b/app/javascript/components/profile_modal.js
@@ -45,7 +45,8 @@ const profileModal = () => {
         const mb2_13 = document.getElementById('mb2-13')
         const mb2_14 = document.querySelector('.mb2-14')
         const mb2_15 = document.getElementById('mb2-15')
-
+        const industryFrom = document.getElementById('industry-from').innerText
+        
         mb2_1.innerText = matchedFirstNm
         mb2_2.innerText = matchedLastNm
         mb2_3.innerText = matchedLocation
@@ -59,16 +60,17 @@ const profileModal = () => {
         mb2_11.innerText = matchedSatisfaction
         mb2_12.innerText = matchedAdvice
         mb2_13.innerText = matchedMotivation
-        
+              
         const img_1 = '<img class="img-fluid" style="vertical-align:middle; width:80px; height: 80px; border-radius: 50%;" src="'
         const img_3 = '" alt="">'
 
         mb2_14.innerHTML = `${img_1}${matchedImgURL}${img_3}`
 
         const mb2_15_1 = '<a href="/roadmaps/'
+        const mb2_15_2 = `?${industryFrom}|${mb2_6.innerText}`
         const mb2_15_3 = '" id="mb2-15" class="btn btn-success mr-2 mr-md-3 rounded-pill px-2 px-md-4">See Roadmap</a>'
 
-        mb2_15.innerHTML = `${mb2_15_1}${matchedRoadmap}${mb2_15_3}`
+        mb2_15.innerHTML = `${mb2_15_1}${matchedRoadmap}${mb2_15_2}${mb2_15_3}`
 
         $("#modalTwo").modal("show");   
       }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ require("@rails/activestorage").start()
 require("channels")
 
 import 'bootstrap';
+import { backToResults } from '../components/back_to_results';
 
 import { profileModal } from '../components/profile_modal';
 
@@ -22,4 +23,5 @@ document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
   profileModal();
+  backToResults();
 });

--- a/app/views/pages/results.html.erb
+++ b/app/views/pages/results.html.erb
@@ -1,6 +1,5 @@
 <h1 class="display-5">Career Switcher Match Results !</h1>
-<br>
-<h3><span class="text-italic"> from </span><strong><%= @industry_from %></strong> <span class="text-italic"> to </span><strong><%= @industry_to %></strong> </h3>
+<h3><span class="text-italic"> from </span><strong><span id="industry-from"><%= @industry_from %><span></strong> <span class="text-italic"> to </span><strong><%= @industry_to %></strong> </h3>
 
 <h5><%= @shortlist_msg %></h5>
 <hr>
@@ -12,7 +11,7 @@
       <img class="matched-user-image img-fluid" style="vertical-align:middle; width:70px; height: 70px; border-radius: 50%;" src="<%= matched_user.img_url %>" alt="">
     </div>
     <br>
-    <h3 class="text-center"><span class="first-name"><%= matched_user.first_name %></span> <span class="last-name"><%= matched_user.last_name %></span></h3>
+    <h3 class="text-center rd1-h4"><span class="first-name"><%= matched_user.first_name %></span> <span class="last-name"><%= matched_user.last_name %></span></h3>
     <br>
     <p class="current-role font-weight-bold"><%= matched_user.current_role %>, </p>
     <p class="current-ind font-weight-bold"><%= matched_user.current_industry %></p>
@@ -49,19 +48,17 @@
 
 <!-- Modal Two - User Signed In -->
 <div class="modal fade" id="modalTwo" tabindex="-1" aria-labelledby="modalTwoLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
+  <div class="modal-dialog modal-xl top-zero">
     <div class="modal-content">
       <div class="modal-dialog modal-xl">
         <div class="mb2-14 text-center">
           <img class="img-fluid" style="vertical-align:middle; width:70px; height: 70px; border-radius: 50%;" src="#" alt="">
         </div>
         <br>
-        <h3><span id="mb2-1"></span> <span id="mb2-2"></h3>
+        <h3 class="rd1-h3"><span id="mb2-1"></span> <span id="mb2-2"></h3>
         <p>Location: <span id="mb2-3"></span></p>
-        <p>from <span id="mb2-4"></span>, <span id="mb2-5"></span></p>
-        <p>To <span id="mb2-6"></span></p>
-        <p>Timeframe <span id="mb2-7"> weeks</span></p>
-        <p>Budget: USD<span id="mb2-8"></span></p>
+        <p>from <strong><span id="mb2-4"></span>, <span id="mb2-5"></span></strong> to <strong><span id="mb2-6"></span></strong></p>
+        <p>Timeframe <span id="mb2-7"> weeks</span> Budget: USD<span id="mb2-8"></span></p>
         <p>Available Hours Per Week <span id="mb2-9"></span></p>
         <p>Journey Experience <span id="mb2-10"></span></p>
         <p>Satisfaction <span id="mb2-11"></span></p>

--- a/app/views/roadmaps/show.html.erb
+++ b/app/views/roadmaps/show.html.erb
@@ -1,5 +1,13 @@
+<div id="back-to-results">
+  <a href="#" class="btn btn-outline-success rounded-pill" style="float: left;">Back to Results</a>
+</div>
+<br>
+<br>
+<br>
+
 <div class="media">
   <img src="<%= @roadmap.user.img_url %>" class="mr-3" width="193" height="193" alt="pic">
+
   <div class="media-body" style="text-align:left;">
     <h4 class="mt-0 rd1-h3"><%= @roadmap.user.first_name %> <%= @roadmap.user.last_name %></h4>
     <blockquote class="blockquote text-right">


### PR DESCRIPTION
Test Video:
https://www.loom.com/share/568b26262f9d48c1aaad9c1571556b5a

Summary of Change:
Added a feature for user to go back to the Search Results page when he/she comes to the "See Roadmap" from the Modal showing the matched user's details.

I realised this is not as simple as putting a link_to button in the User's Roadmap page because when we go back to the Search Results, the params are no longer available (they come from Landing page to Results page, but obviously don't exist when you try to go back !)

We cannot even use Current User's role and industry in trying to construct the path back. Because the Search results that we started with - there may not have been any exact matches.

In the video, I have shown both cases (1) where we search Current Role and Target Industry and we have users who match both and (2) where we search Current Role and Target Industry and we have users who match only the Target Industry. In the second case, we will not have access to the Current Role that was entered by the User in the landing page, when we try to go back.

So I had to use a combination of Javascript to pass the user-entered Current Rome from the modal to the "See Roadmap" page, put it into the Query String when sending it to /roadmap/id, and I have a JS which gets that QueryString and constructs the URL path for the "back to results" button in the "roadmap/id" page

