### PR TITLE
add order field to CourseRoadmap

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,4 @@
 class Course < ApplicationRecord
   belongs_to :topic
-  has_many :course_roadmaps, dependent: :destroy 
+  has_many :course_roadmaps, dependent: :destroy
 end

--- a/app/models/roadmap.rb
+++ b/app/models/roadmap.rb
@@ -1,6 +1,6 @@
 class Roadmap < ApplicationRecord
   belongs_to :user
 
-  has_many :course_roadmaps, dependent: :destroy 
+  has_many :course_roadmaps, dependent: :destroy
   has_many :courses, through: :course_roadmaps
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,3 @@
 class Topic < ApplicationRecord
-  has_many :courses
+  has_many :courses, dependent: :destroy
 end

--- a/db/migrate/20210615140433_add_order_to_course_roadmaps.rb
+++ b/db/migrate/20210615140433_add_order_to_course_roadmaps.rb
@@ -1,0 +1,5 @@
+class AddOrderToCourseRoadmaps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_roadmaps, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_045151) do
+ActiveRecord::Schema.define(version: 2021_06_15_140433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_06_11_045151) do
     t.bigint "roadmap_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "order"
     t.index ["course_id"], name: "index_course_roadmaps_on_course_id"
     t.index ["roadmap_id"], name: "index_course_roadmaps_on_roadmap_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -299,7 +299,6 @@ def seedCoursesRoadmapsJoinTable
     c_idx = 0
     18.times do
       course_to_get = courses_array[c_idx]
-
       # puts "Roadmap ID: #{roadmap_id} Course to Get: #{course_to_get}"
 
       if course_to_get > 0
@@ -310,7 +309,8 @@ def seedCoursesRoadmapsJoinTable
       CourseRoadmap.create!(
         status: statuses.sample,
         course_id: course.id,
-        roadmap_id: roadmap_id
+        roadmap_id: roadmap_id,
+        order: c_idx + 1
       )
       end
       c_idx += 1


### PR DESCRIPTION
Changes made:
1. Created Migration to Add Order field (integer) to CourseRoadmap table
2. Changed Seed so that the Order field will be incremented by 1 for each course that is created for each Roadmap in the CourseRoadmap table. For example, if we are creating 5 courses for Roadmap ID "234", the rows will be as follows:
Roadmap ID     Course ID     Order
234                         56              1
234                         57              2
234                         34              3
234                         14              4
234                         23              5

3. Added dependent: :destroy to Topic model so that destroy_all on topic will destroy dependent courses.

Testing:
Have run the seed and it runs OK - see end of run stats below
![image](https://user-images.githubusercontent.com/67267830/122071406-4ade5d80-ce29-11eb-93a8-10caeab11b3c.png)

