### PR TITLE
fix-link-back-from-see-roadmap-page

### DIFF
--- a/app/javascript/components/back_to_results.js
+++ b/app/javascript/components/back_to_results.js
@@ -2,21 +2,15 @@ const backToResults = () => {
   const backToResultsBtn = document.getElementById('back-to-results');
 
   if (backToResultsBtn) {
-    const queryString = location.search.substring(1);
-    const newString = queryString.replace(/%20/g, "+");
-    const tmpArray = newString.split("|")
-    const btnP2 = tmpArray[0];
-    const btnP4 = tmpArray[1];
-    // console.log(`${btnP2} ${btnP4}`)
-
     const backToResultsBtn = document.getElementById('back-to-results');
-    // console.log(backToResultsBtn.innerHTML);
+    console.log(backToResultsBtn.innerHTML);
+    const currentURL = sessionStorage.getItem('currentURL');
+    console.log(currentURL);
+    
+    const btnP1 = '<a href="'
+    const btnP3 = '" class="btn btn-outline-success rounded-pill"   style="float: left;">Back to Results</a>'
 
-    const btnP1 = '<a href="/results?query_from='
-    const btnP3 = '&query_to='
-    const btnP5 = '&commit=Search" class="btn btn-outline-success rounded-pill"   style="float: left;">Back to Results</a>'
-
-    backToResultsBtn.innerHTML = `${btnP1}${btnP2}${btnP3}${btnP4}${btnP5}`
+    backToResultsBtn.innerHTML = `${btnP1}${currentURL}${btnP3}`
   }
 }
 

--- a/app/javascript/components/profile_modal.js
+++ b/app/javascript/components/profile_modal.js
@@ -66,11 +66,25 @@ const profileModal = () => {
 
         mb2_14.innerHTML = `${img_1}${matchedImgURL}${img_3}`
 
+        // store the current URL in sessionStorage
+        // When this modal gets redirected to "See Roadmap",
+        // the link-back button on that page will
+        // need to reconstruct the My Results URL on the way back, so it 
+        // will use the URL saved in sessionStorage
+
+        const currentURL = window.location.href;
+        console.log(currentURL);
+
+        sessionStorage.removeItem('currentURL');
+        sessionStorage.setItem('currentURL', currentURL);
+        console.log(sessionStorage.getItem('currentURL'));
+                
         const mb2_15_1 = '<a href="/roadmaps/'
-        const mb2_15_2 = `?${industryFrom}|${mb2_6.innerText}`
         const mb2_15_3 = '" id="mb2-15" class="btn btn-success mr-2 mr-md-3 rounded-pill px-2 px-md-4">See Roadmap</a>'
 
-        mb2_15.innerHTML = `${mb2_15_1}${matchedRoadmap}${mb2_15_2}${mb2_15_3}`
+        mb2_15.innerHTML = `${mb2_15_1}${matchedRoadmap}${mb2_15_3}`
+
+        console.log(mb2_15.innerHTML)
 
         $("#modalTwo").modal("show");   
       }


### PR DESCRIPTION
Test Video:
https://www.loom.com/share/fbfa6691e07f4177a5d46c8f6d677898

Changes in this Commit:
1, After User signs-in and does a search from the Home Page, he/she goes to My Results page.
2. User then selects any  matched profile and a modal pops up showing matched Profile details.
3. In this modal view, User can click on "See Roadmap" button which goes to the /roadmap/roadmap_id page where roadmap_id is the roadmap of the profiled user.
4. The "See Roadmap page" has a button to link back to "My Results" page, and this link needs to know what URL it came from (i.e. the full URL of the My Results page with the queryString included)

In this change, I am saving the current URL in sessionStorage, when the My Results JS function executes and "shows" the modal. In the "See Roadmap" page, I get the current URL from sessionStorage and create the back-link button with the URL that got generated when "My Results" was loaded, as it was saved in sessionStorage.

Reason for using sessionStorage is that we need to pass this bit of info from one page to another only in the current session. After user has closed browser, we don't need that info again when he/she signs-in again.


