### PR TITLE
fix-my-network-cards-layout

### DIFF
--- a/app/assets/stylesheets/components/_connection-each-card.scss
+++ b/app/assets/stylesheets/components/_connection-each-card.scss
@@ -1,5 +1,5 @@
 .connection-each-image {
-  height: 128px;
+  height: 132px;
   width: 128px;
   img {
     height: 100%;

--- a/app/views/pages/_connection_each_card.html.erb
+++ b/app/views/pages/_connection_each_card.html.erb
@@ -1,10 +1,11 @@
 <div class="col-12 col-md-6 mb-5">
-  <div class="d-flex flex-wrap justify-content-between border border-black rounded rounded-lg">
+  <div class="d-flex flex-wrap justify-content-between " style="background-color: white; border: 1px solid rgb(225,225, 225);
+  border-radius: 8px;">
     <div class="connection-each-image position-relative col-4 col-md-3 px-0">
       <img class="connection_each-image" src="<%= @cnctn_usr_img %>" alt="<% @cnctn_usr_name %>">
     </div>
     <div class="connection-each-info p-2 position-relative col-8 col-md-9">
-      <h3 class="font-weight-bold text-success"><%= @cnctn_usr_name %></h3>
+      <h3 class="font-weight-bold" style="color: green; margin-top:2px;"><%= @cnctn_usr_name %></h3>
       <p class="text-secondary mb-2"><%= @cnctn_usr_loc %></p>
       <div class="py-2">
         <%= link_to 'Chat', chat_path(cnctn.id), class: 'btn btn-sm rounded-pill btn-secondary px-4' %>

--- a/app/views/pages/networks.html.erb
+++ b/app/views/pages/networks.html.erb
@@ -1,4 +1,4 @@
-<h2>My Network</h2>
+<h2 style="margin-left: 100px;">My Network</h2>
 <div class="sidenav">
   <div class="sidenav-text">
     <%= link_to dashboard_page_path do %>
@@ -13,25 +13,24 @@
   </div>
 </div>
 
-<section class="connections-container">
-  <div class="container">
-    <div class="row mt-5">
-      <% @connections.each do |cnctn| %>
-        <% if cnctn.connected_id == current_user.id %>
-          <% cnctn_usr_fst_nm = User.find(cnctn.connecting_id).first_name %>
-          <% cnctn_usr_lst_nm = User.find(cnctn.connecting_id).last_name %>
-          <% @cnctn_usr_name = "#{cnctn_usr_fst_nm} #{cnctn_usr_lst_nm}" %>
-          <% @cnctn_usr_loc = User.find(cnctn.connecting_id).location %>
-          <% @cnctn_usr_img = User.find(cnctn.connecting_id).img_url %>
-        <% else %>
-          <% cnctn_usr_fst_nm = User.find(cnctn.connected_id).first_name %>
-          <% cnctn_usr_lst_nm = User.find(cnctn.connected_id).last_name %>
-          <% @cnctn_usr_name = "#{cnctn_usr_fst_nm} #{cnctn_usr_lst_nm}" %>
-          <% @cnctn_usr_loc = User.find(cnctn.connected_id).location %>
-          <% @cnctn_usr_img = User.find(cnctn.connected_id).img_url %>
-        <% end %>
-        <%= render 'connection_each_card', cnctn: cnctn %>
+<section class="connections-container" style="margin-left: 120px;">
+  <div class="row mt-5">
+    <% @connections.each do |cnctn| %>
+      <% if cnctn.connected_id == current_user.id %>
+        <% cnctn_usr_fst_nm = User.find(cnctn.connecting_id).first_name %>
+        <% cnctn_usr_lst_nm = User.find(cnctn.connecting_id).last_name %>
+        <% @cnctn_usr_name = "#{cnctn_usr_fst_nm} #{cnctn_usr_lst_nm}" %>
+        <% @cnctn_usr_loc = User.find(cnctn.connecting_id).location %>
+        <% @cnctn_usr_img = User.find(cnctn.connecting_id).img_url %>
+      <% else %>
+        <% cnctn_usr_fst_nm = User.find(cnctn.connected_id).first_name %>
+        <% cnctn_usr_lst_nm = User.find(cnctn.connected_id).last_name %>
+        <% @cnctn_usr_name = "#{cnctn_usr_fst_nm} #{cnctn_usr_lst_nm}" %>
+        <% @cnctn_usr_loc = User.find(cnctn.connected_id).location %>
+        <% @cnctn_usr_img = User.find(cnctn.connected_id).img_url %>
       <% end %>
-    </div>
+      <%= render 'connection_each_card', cnctn: cnctn %>
+      <% end %>
   </div>
+  
 </section>


### PR DESCRIPTION
Changes in this Commit:
My Networks page layout was disturbed due to a extra container div that was there in app/views/pages/_connection_each_card.html.erb.

I have fixed the layout, but I have used in-line styling for now, this is **ONLY** a temporary solution as we are expecting to change the front-end styling once Minyoung finalises a theme.

Please see Before Changes and After Changes images of the page

**BEFORE** 
![MyNetworksBefore](https://user-images.githubusercontent.com/67267830/122141228-768c3280-ce7f-11eb-800a-78719710cb2c.JPG)

**AFTER** 

![MyNetworksAfter](https://user-images.githubusercontent.com/67267830/122141240-7db34080-ce7f-11eb-8e83-d35f76836dc1.JPG)
