### PR TITLE
save-additional-user-fields-at-signup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,8 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
   before_action :persist_last_visited_path
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 
   def after_sign_in_path_for(_resource)
@@ -8,6 +11,14 @@ class ApplicationController < ActionController::Base
     else
       root_path
     end
+  end
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[current_role current_industry future_role])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[current_role current_industry future_role])
   end
 
   private

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,34 @@
 <h2>Sign up</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+<%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
+<div class="form-inputs">
+  <%= f.input :email,
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
+  <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
+  <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
-  </div>
+  <%= f.hidden_field :current_role,
+                required: true,
+                value: params[:c_role] %>
+  <%= f.hidden_field :current_industry,
+                required: true,
+                value: params[:c_ind] %>
+  <%= f.hidden_field :future_role,
+                required: true,
+                value: params[:t_role] %>
+</div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
+<div class="form-actions">
+  <%= f.button :submit, "Sign up" %>
+</div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/pages/results.html.erb
+++ b/app/views/pages/results.html.erb
@@ -6,6 +6,8 @@
 
 <div class="d-flex flex-wrap justify-content-between align-items-center">
   <% @shortlisted_profiles.each do |matched_user| %>
+  <% next if matched_user.img_url.nil? %>
+  <% matched_user.roadmap.nil? ? match_rdmp_id = 0 : match_rdmp_id = matched_user.roadmap.id %>
   <div class="profiles card mt-3 mb-3 border border-success" style="width: 16rem; height: 25rem;">
     <div class="matched-img-div text-center">
       <img class="matched-user-image img-fluid" style="vertical-align:middle; width:70px; height: 70px; border-radius: 50%;" src="<%= matched_user.img_url %>" alt="">
@@ -18,7 +20,7 @@
     <p class="text-muted">to</p>
     <p class="future-ind font-weight-bold"><%= matched_user.future_industry %></p>
 
-    <button class="myBtn btn btn-success" type="button" data-target="modalOne" data-matched-first-nm="<%= matched_user.first_name %>" data-matched-user-id="<%= matched_user.id %>" data-matched-first-nm="<%= matched_user.first_name %>" data-matched-last-nm="<%= matched_user.last_name %>" data-matched-current-role="<%= matched_user.current_role %>" data-matched-current-ind="<%= matched_user.current_industry %>" data-matched-fut-ind="<%= matched_user.future_industry %>" data-matched-img="<%= matched_user.img_url %>" data-matched-location="<%= matched_user.location %>" data-matched-motivation="<%= matched_user.motivation %>" data-matched-satisfaction="<%= matched_user.satisfaction %>" data-matched-experience="<%= matched_user.journey_experience %>" data-matched-advice="<%= matched_user.advice %>" data-matched-budget="<%= matched_user.budget %>" data-matched-timeframe="<%= matched_user.timeframe %>" data-matched-hrs="<%= matched_user.available_hrs_per_week %>" data-matched-roadmap="<%= matched_user.roadmap.id %>">More!</button>
+    <button class="myBtn btn btn-success" type="button" data-target="modalOne" data-matched-first-nm="<%= matched_user.first_name %>" data-matched-user-id="<%= matched_user.id %>" data-matched-first-nm="<%= matched_user.first_name %>" data-matched-last-nm="<%= matched_user.last_name %>" data-matched-current-role="<%= matched_user.current_role %>" data-matched-current-ind="<%= matched_user.current_industry %>" data-matched-fut-ind="<%= matched_user.future_industry %>" data-matched-img="<%= matched_user.img_url %>" data-matched-location="<%= matched_user.location %>" data-matched-motivation="<%= matched_user.motivation %>" data-matched-satisfaction="<%= matched_user.satisfaction %>" data-matched-experience="<%= matched_user.journey_experience %>" data-matched-advice="<%= matched_user.advice %>" data-matched-budget="<%= matched_user.budget %>" data-matched-timeframe="<%= matched_user.timeframe %>" data-matched-hrs="<%= matched_user.available_hrs_per_week %>" data-matched-roadmap="<%= match_rdmp_id %>">More!</button>
   </div>
   <% end %>
 </div>
@@ -39,8 +41,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-dark rounded-pill px-2 px-md-4" data-dismiss="modal">Close</button>
         <%= link_to 'Sign in', new_user_session_path, class: 'btn btn-primary mr-2 mr-md-3 rounded-pill px-2 px-md-4' %>
-        <!-- <button type="button" class="btn btn-primary">Sign in</button> -->
-        <%= link_to 'Sign Up', new_user_registration_path, class: 'btn btn-success rounded-pill px-2 px-md-4' %>
+        <%= link_to 'Sign Up', new_user_registration_path(:c_role => params[:query_role], :c_ind => params[:query_from], :t_role => params[:query_to]), class: 'btn btn-success rounded-pill px-2 px-md-4' %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Test Video:**
https://www.loom.com/share/8242db8a262644f996c6b74151e26c02

**Changes in this Commit:**
1. When a Visitor does a search from the landing page, sees Search Results, he/she is asked to Sign-In or Sign-Up
2. If the Visitor does a Sign-Up, then the "Current Role", "Current Industry" and "Future Role" entered by the Visitor in the home page, is automatically updated into the User Profile that is created.

**Notes:**
1. We can see the result of this Change in My Dashboard after the User signs up. However, there is a bug in "My Dashboard" where the "Current Industry" is not being shown correctly, it is showing the "Current Role". 
But the actual User table is updated correctly (see rails console screenshot).

2. Implementing this mini-feature introduces a new "problem" - we now have a new User with current role, current industry, and future role - but no other details like Name, Image URL, etc. so we need to exclude this User, when matching profiles in our Search. I have made this fix also.

Rails console screenshot showing Current Role, Current Industry and Target Role updated
![image](https://user-images.githubusercontent.com/67267830/122623784-0b856a80-d0d0-11eb-898a-484addeba0e2.png)


